### PR TITLE
Add package manifest file for PlatformIO integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "framework-arduinoespressif32-libs",
+  "version": "5.1.0+sha.420ebd208a",
+  "description": "Precompiled libraries for Arduino Wiring-based Framework for the Espressif ESP32, ESP32-S and ESP32-C series of SoCs",
+  "keywords": [
+    "framework",
+    "arduino",
+    "espressif",
+    "esp32"
+  ],
+  "license": "LGPL-2.1-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/espressif/arduino-esp32"
+  }
+} 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "framework-arduinoespressif32-libs",
   "version": "5.1.0+sha.420ebd208a",
-  "description": "Precompiled libraries for Arduino Wiring-based Framework for the Espressif ESP32, ESP32-S and ESP32-C series of SoCs",
+  "description": "Precompiled libraries for Arduino Wiring-based Framework for the Espressif ESP32 series of SoCs",
   "keywords": [
     "framework",
     "arduino",
@@ -13,4 +13,4 @@
     "type": "git",
     "url": "https://github.com/espressif/esp32-arduino-libs"
   }
-} 
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "LGPL-2.1-or-later",
   "repository": {
     "type": "git",
-    "url": "https://github.com/espressif/arduino-esp32"
+    "url": "https://github.com/espressif/esp32-arduino-libs"
   }
 } 


### PR DESCRIPTION
With this file developers will be able to override default package dynamically using the [platform_packages](https://docs.platformio.org/en/latest/projectconf/sections/env/options/platform/platform_packages.html) option.

cc @me-no-dev 